### PR TITLE
Phyton -> Python

### DIFF
--- a/keywords.csv
+++ b/keywords.csv
@@ -31,3 +31,4 @@ supposably,supposedly
 "chomping at the bit","champing at the bit"
 "just desserts","just deserts"
 "deep seeded","deep seated"
+"phyton","python"


### PR DESCRIPTION
"Phyton" is a very common misspelling for "python", used to refer both Python, the programming language, and The Monty Python. (and sometimes the animal). 

I even joked about this in the past. 
https://twitter.com/tin_nqn_/statuses/372660413281730561
