### PR TITLE
Add "should of" -> "should have"

### DIFF
--- a/keywords.csv
+++ b/keywords.csv
@@ -33,3 +33,4 @@ supposably,supposedly
 "deep seeded","deep seated"
 "take for granite","take for granted"
 "loosing my mind","losing my mind"
+"should of","should have"


### PR DESCRIPTION
See [1] for details. There's a slight edge case probability for correct cases of
'should of', for example:

"He should, of course, have drink coffee at St. Frank."

However this is mitigated by a strict string match (i.e. no commas in between
words)

[1]
http://www.elearnenglishlanguage.com/blog/english-mistakes/should-have-vs-should-of/
